### PR TITLE
Add deferred call to run coffee controller if current controller is only set after CoffeeControllers init

### DIFF
--- a/app/assets/javascripts/coffee_controllers/core.js.coffee
+++ b/app/assets/javascripts/coffee_controllers/core.js.coffee
@@ -26,6 +26,8 @@
 # Store a given controller object by its name in the @Controllers
 @setController = (controllerName, controllerObj) ->
   @Controllers[controllerName] = controllerObj
+  ready ->
+    runCoffeeController() if isCurrentController(controllerName) && controllerObj != getCurrentController()
   return
 
 # Get a given controller object by its name from the @Controllers
@@ -35,3 +37,8 @@
 # Get the current active controller object
 @getCurrentController = ->
   @ActiveController
+
+# Check if a given controller is the current by name
+@isCurrentController = (controllerName) ->
+  body = document.querySelectorAll('body')[0]
+  return body.getAttribute('data-controller').replace(/\//g, '_') == controllerName

--- a/app/assets/javascripts/coffee_controllers/loader.js.coffee
+++ b/app/assets/javascripts/coffee_controllers/loader.js.coffee
@@ -1,12 +1,12 @@
 # Attach a function to be executed when the DOM is loaded
-ready = (fn) ->
+@ready = (fn) ->
   unless document.readyState is "loading"
     fn()
   else
     document.addEventListener "DOMContentLoaded", fn
   return
 
-ready ->
+@ready ->
   # Run the specific scripts that have to be run after the DOM is loaded
   runCoffeeController()
   return

--- a/test/dummy/app/assets/javascripts/deferred.js.coffee
+++ b/test/dummy/app/assets/javascripts/deferred.js.coffee
@@ -1,0 +1,14 @@
+class DeferredController
+  init: ->
+    @body = document.querySelectorAll('body')[0]
+    @body.insertAdjacentHTML 'afterend', 'deferred page loaded'
+
+  index: ->
+    @body.insertAdjacentHTML 'afterend', 'deferred index content'
+
+
+setTimeout () ->
+  setController 'deferred', new DeferredController()
+, 5000
+# Make sure to change the time here if you override capybara's default wait time (2)
+# Time may change depending on how much time each assertion takes

--- a/test/dummy/app/assets/stylesheets/deferred.css
+++ b/test/dummy/app/assets/stylesheets/deferred.css
@@ -1,0 +1,4 @@
+/*
+  Place all the styles related to the matching controller here.
+  They will automatically be included in application.css.
+*/

--- a/test/dummy/app/controllers/deferred_controller.rb
+++ b/test/dummy/app/controllers/deferred_controller.rb
@@ -1,0 +1,3 @@
+class DeferredController < ApplicationController
+  def index;end
+end

--- a/test/dummy/app/helpers/deferred_helper.rb
+++ b/test/dummy/app/helpers/deferred_helper.rb
@@ -1,0 +1,2 @@
+module DeferredHelper
+end

--- a/test/dummy/config/routes.rb
+++ b/test/dummy/config/routes.rb
@@ -1,4 +1,5 @@
 Rails.application.routes.draw do
   get '/home', to: 'main#home'
   get '/dashboard', to: 'main#dashboard'
+  get '/deferred', to: 'deferred#index'
 end

--- a/test/integration_test.rb
+++ b/test/integration_test.rb
@@ -17,5 +17,12 @@ class IntegrationTest < ActionDispatch::IntegrationTest
     assert page.has_content?('page loaded'), 'should run the init() function when dashboard is ready'
     assert page.has_content?('dashboard content'), 'should run the dashboard() function when dashboard is ready'
     assert !page.has_content?('home content'), 'should not run the home() function when dashboard is ready'
+
+    visit '/deferred'
+    assert !page.has_content?('deferred page loaded'), 'should not run init() function when deferred is ready'
+    assert !page.has_content?('deferred index content'), 'should not run index() function when deferred is ready'
+    sleep 1
+    assert page.has_content?('deferred page loaded'), 'should run index() function when deferred controller is set'
+    assert page.has_content?('deferred index content'), 'should run index() function when deferred controller is set'
   end
 end


### PR DESCRIPTION
Applications in production without Turbolinks, on coffee controllers often run CoffeeControllers initialization BEFORE setting the controller during navigation, causing the application to break without warning. This PR makes `setController` execute `runCoffeeController` , if the controller being set is expected to run;
